### PR TITLE
Add threshold encryption demo

### DIFF
--- a/go/tdh2/cmd/demo/main.go
+++ b/go/tdh2/cmd/demo/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+
+	tdh2easy "github.com/smartcontractkit/tdh2/go/tdh2/tdh2easy"
+)
+
+func main() {
+	// server generates keys and distributes shares to n nodes with threshold k
+	k, n := 3, 5
+	_, pk, shares, err := tdh2easy.GenerateKeys(k, n)
+	if err != nil {
+		panic(fmt.Errorf("generate keys: %w", err))
+	}
+
+	// client encrypts a message using the public key
+	msg := []byte("hello threshold encryption")
+	ctxt, err := tdh2easy.Encrypt(pk, msg)
+	if err != nil {
+		panic(fmt.Errorf("encrypt: %w", err))
+	}
+
+	// nodes create decryption shares for the ciphertext
+	decShares := make([]*tdh2easy.DecryptionShare, 0, k)
+	for i := 0; i < k; i++ {
+		ds, err := tdh2easy.Decrypt(ctxt, shares[i])
+		if err != nil {
+			panic(fmt.Errorf("decrypt share %d: %w", i, err))
+		}
+		decShares = append(decShares, ds)
+	}
+
+	// server verifies shares and combines them to recover the message
+	for _, s := range decShares {
+		if err := tdh2easy.VerifyShare(ctxt, pk, s); err != nil {
+			panic(fmt.Errorf("verify share: %w", err))
+		}
+	}
+	recovered, err := tdh2easy.Aggregate(ctxt, decShares, n)
+	if err != nil {
+		panic(fmt.Errorf("aggregate: %w", err))
+	}
+
+	fmt.Printf("Original message: %s\n", msg)
+	fmt.Printf("Recovered message: %s\n", recovered)
+}

--- a/go/tdh2/cmd/demo_tdh2/main.go
+++ b/go/tdh2/cmd/demo_tdh2/main.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	cryptorand "crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	"github.com/smartcontractkit/tdh2/go/tdh2/lib/group/nist"
+	tdh2 "github.com/smartcontractkit/tdh2/go/tdh2/tdh2"
+)
+
+// newStream returns a fresh random stream for use with TDH2 operations.
+func newStream() cipher.Stream {
+	block, err := aes.NewCipher(make([]byte, 16))
+	if err != nil {
+		panic(fmt.Errorf("NewCipher: %w", err))
+	}
+	iv := make([]byte, aes.BlockSize)
+	if _, err := cryptorand.Read(iv); err != nil {
+		panic(fmt.Errorf("Read: %w", err))
+	}
+	return cipher.NewCTR(block, iv)
+}
+
+func main() {
+	// server generates keys and distributes shares to n nodes with threshold k
+	group := nist.NewP256()
+	k, n := 3, 5
+	_, pk, shares, err := tdh2.GenerateKeys(group, nil, k, n, newStream())
+	if err != nil {
+		panic(fmt.Errorf("generate keys: %w", err))
+	}
+
+	// client encrypts a message using the public key and produces a proof
+	msg := []byte("hello threshold proof messages!!")
+	label := []byte("label for threshold demo proof!!")
+	ctxt, err := tdh2.Encrypt(pk, msg, label, newStream())
+	if err != nil {
+		panic(fmt.Errorf("encrypt: %w", err))
+	}
+
+	// show and verify encryption proof (e,f)
+	var cproof struct {
+		E []byte
+		F []byte
+	}
+	if raw, err := ctxt.Marshal(); err == nil {
+		_ = json.Unmarshal(raw, &cproof)
+		fmt.Printf("ciphertext proof e=%s f=%s\n", hex.EncodeToString(cproof.E), hex.EncodeToString(cproof.F))
+	}
+	if err := ctxt.Verify(pk); err != nil {
+		panic(fmt.Errorf("verify ciphertext: %w", err))
+	}
+	fmt.Println("ciphertext proof verified")
+
+	// nodes create decryption shares with proofs for the ciphertext
+	decShares := make([]*tdh2.DecryptionShare, 0, k)
+	for i := 0; i < k; i++ {
+		ds, err := ctxt.Decrypt(group, shares[i], newStream())
+		if err != nil {
+			panic(fmt.Errorf("decrypt share %d: %w", i, err))
+		}
+		// show and verify decryption proof (e_i,f_i)
+		var sproof struct {
+			E_i []byte
+			F_i []byte
+		}
+		if raw, err := ds.Marshal(); err == nil {
+			_ = json.Unmarshal(raw, &sproof)
+			fmt.Printf("share %d proof e_i=%s f_i=%s\n", ds.Index(), hex.EncodeToString(sproof.E_i), hex.EncodeToString(sproof.F_i))
+		}
+		if err := tdh2.VerifyShare(pk, ctxt, ds); err != nil {
+			panic(fmt.Errorf("verify share %d: %w", i, err))
+		}
+		fmt.Printf("share %d proof verified\n", ds.Index())
+		decShares = append(decShares, ds)
+	}
+
+	// server combines verified shares to recover the message
+	recovered, err := ctxt.CombineShares(group, decShares, k, n)
+	if err != nil {
+		panic(fmt.Errorf("combine: %w", err))
+	}
+
+	fmt.Printf("original message: %s\n", msg)
+	fmt.Printf("recovered message: %s\n", recovered)
+}


### PR DESCRIPTION
## Summary
- add runnable `tdh2` demo illustrating key generation, encryption with proof verification, decryption share proofs, and aggregation
- retain existing `tdh2easy` demo for simpler usage

## Testing
- `go test ./...`
- `go run ./cmd/demo_tdh2`


------
https://chatgpt.com/codex/tasks/task_b_68937eb34d288328ba848762d94302e3